### PR TITLE
Rename `HasXXX` methods `ContainsXXX`

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -9,8 +9,8 @@ import (
 func ExampleSet_Has() {
 	s := set.New(1, 2)
 
-	fmt.Println(s.Has(1))
-	fmt.Println(s.Has(0))
+	fmt.Println(s.Contains(1))
+	fmt.Println(s.Contains(0))
 	// Output:
 	// true
 	// false
@@ -19,8 +19,8 @@ func ExampleSet_Has() {
 func ExampleSet_HasAll() {
 	s := set.New("foo", "bar")
 
-	fmt.Println(s.HasAll("foo", "bar"))
-	fmt.Println(s.HasAll("foo", "bar", "baz"))
+	fmt.Println(s.ContainsAll("foo", "bar"))
+	fmt.Println(s.ContainsAll("foo", "bar", "baz"))
 	// Output:
 	// true
 	// false

--- a/set.go
+++ b/set.go
@@ -47,7 +47,7 @@ func (s *Set[V]) Difference(t *Set[V]) *Set[V] {
 	u := New[V]()
 
 	for k := range s.m {
-		if !t.Has(k) {
+		if !t.Contains(k) {
 			u.Insert(k)
 		}
 	}
@@ -76,7 +76,7 @@ func (s *Set[V]) Intersection(t *Set[V]) *Set[V] {
 	}
 
 	for k := range walk.m {
-		if other.Has(k) {
+		if other.Contains(k) {
 			u.Insert(k)
 		}
 	}
@@ -92,16 +92,16 @@ func (s *Set[V]) Equal(t *Set[V]) bool {
 	return len(s.m) == len(t.m) && s.IsSuperset(t)
 }
 
-// Has returns true iff `s` contains a given value.
-func (s *Set[V]) Has(v V) bool {
+// Contains returns true iff `s` contains a given value.
+func (s *Set[V]) Contains(v V) bool {
 	_, ok := s.m[v]
 	return ok
 }
 
 // HasAny returns true iff `s` contains all the given values.
-func (s *Set[V]) HasAll(v ...V) bool {
+func (s *Set[V]) ContainsAll(v ...V) bool {
 	for _, x := range v {
-		if !s.Has(x) {
+		if !s.Contains(x) {
 			return false
 		}
 	}
@@ -110,9 +110,9 @@ func (s *Set[V]) HasAll(v ...V) bool {
 }
 
 // HasAll returns true iff `s` contains any of the given values.
-func (s *Set[V]) HasAny(v ...V) bool {
+func (s *Set[V]) ContainsAny(v ...V) bool {
 	for _, x := range v {
-		if s.Has(x) {
+		if s.Contains(x) {
 			return true
 		}
 	}
@@ -130,7 +130,7 @@ func (s *Set[V]) Insert(v ...V) {
 // IsSuperset returns true iff `t` is a superset of `s`.
 func (s *Set[V]) IsSuperset(t *Set[V]) bool {
 	for k := range t.m {
-		if !s.Has(k) {
+		if !s.Contains(k) {
 			return false
 		}
 	}

--- a/set_test.go
+++ b/set_test.go
@@ -150,7 +150,7 @@ func TestSetHas(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(tt.want, tt.s.Has(tt.v)); diff != "" {
+			if diff := cmp.Diff(tt.want, tt.s.Contains(tt.v)); diff != "" {
 				t.Errorf("(-want +got):\n%s", diff)
 			}
 		})
@@ -186,7 +186,7 @@ func TestSetHasAll(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(tt.want, tt.s.HasAll(tt.v...)); diff != "" {
+			if diff := cmp.Diff(tt.want, tt.s.ContainsAll(tt.v...)); diff != "" {
 				t.Errorf("(-want +got):\n%s", diff)
 			}
 		})
@@ -222,7 +222,7 @@ func TestSetHasAny(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(tt.want, tt.s.HasAny(tt.v...)); diff != "" {
+			if diff := cmp.Diff(tt.want, tt.s.ContainsAny(tt.v...)); diff != "" {
 				t.Errorf("(-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Renames the `HasXXX` methods `ContainsXXX` to follow the naming of [`golang.org/x/exp/slices`](https://pkg.go.dev/golang.org/x/exp/slices).