### PR TITLE
Fix `ContainsXXX` test names and comments

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/micnncim/go-set"
 )
 
-func ExampleSet_Has() {
+func ExampleSet_Contains() {
 	s := set.New(1, 2)
 
 	fmt.Println(s.Contains(1))
@@ -16,7 +16,7 @@ func ExampleSet_Has() {
 	// false
 }
 
-func ExampleSet_HasAll() {
+func ExampleSet_ContainsAll() {
 	s := set.New("foo", "bar")
 
 	fmt.Println(s.ContainsAll("foo", "bar"))

--- a/set.go
+++ b/set.go
@@ -98,7 +98,7 @@ func (s *Set[V]) Contains(v V) bool {
 	return ok
 }
 
-// HasAny returns true iff `s` contains all the given values.
+// ContainsAny returns true iff `s` contains all the given values.
 func (s *Set[V]) ContainsAll(v ...V) bool {
 	for _, x := range v {
 		if !s.Contains(x) {
@@ -109,7 +109,7 @@ func (s *Set[V]) ContainsAll(v ...V) bool {
 	return true
 }
 
-// HasAll returns true iff `s` contains any of the given values.
+// ContainsAll returns true iff `s` contains any of the given values.
 func (s *Set[V]) ContainsAny(v ...V) bool {
 	for _, x := range v {
 		if s.Contains(x) {

--- a/set_test.go
+++ b/set_test.go
@@ -121,7 +121,7 @@ func TestSetEqual(t *testing.T) {
 	}
 }
 
-func TestSetHas(t *testing.T) {
+func TestSetContains(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -131,13 +131,13 @@ func TestSetHas(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "has",
+			name: "contains",
 			s:    set.New(1),
 			v:    1,
 			want: true,
 		},
 		{
-			name: "has no int",
+			name: "not contains int",
 			s:    set.New(1),
 			v:    2,
 			want: false,
@@ -157,7 +157,7 @@ func TestSetHas(t *testing.T) {
 	}
 }
 
-func TestSetHasAll(t *testing.T) {
+func TestSetContainsAll(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -167,13 +167,13 @@ func TestSetHasAll(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "has all",
+			name: "contains",
 			s:    set.New(1, 2, 3),
 			v:    []int{1, 2},
 			want: true,
 		},
 		{
-			name: "not has all",
+			name: "not contains all",
 			s:    set.New(1, 2),
 			v:    []int{1, 2, 3},
 			want: false,
@@ -193,7 +193,7 @@ func TestSetHasAll(t *testing.T) {
 	}
 }
 
-func TestSetHasAny(t *testing.T) {
+func TestSetContainsAny(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -203,13 +203,13 @@ func TestSetHasAny(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "has any",
+			name: "contains any",
 			s:    set.New(1, 2),
 			v:    []int{1, 3},
 			want: true,
 		},
 		{
-			name: "not has any",
+			name: "not contains any",
 			s:    set.New(1, 2),
 			v:    []int{3},
 			want: false,


### PR DESCRIPTION
Fixes the test names and comments of `ContainsXXX`, which missed being done in https://github.com/micnncim/go-set/pull/5.